### PR TITLE
feat: OKLCH color space support

### DIFF
--- a/.metadata
+++ b/.metadata
@@ -15,22 +15,7 @@ migration:
     - platform: root
       create_revision: 67323de285b00232883f53b84095eb72be97d35c
       base_revision: 67323de285b00232883f53b84095eb72be97d35c
-    - platform: android
-      create_revision: 67323de285b00232883f53b84095eb72be97d35c
-      base_revision: 67323de285b00232883f53b84095eb72be97d35c
-    - platform: ios
-      create_revision: 67323de285b00232883f53b84095eb72be97d35c
-      base_revision: 67323de285b00232883f53b84095eb72be97d35c
-    - platform: linux
-      create_revision: 67323de285b00232883f53b84095eb72be97d35c
-      base_revision: 67323de285b00232883f53b84095eb72be97d35c
     - platform: macos
-      create_revision: 67323de285b00232883f53b84095eb72be97d35c
-      base_revision: 67323de285b00232883f53b84095eb72be97d35c
-    - platform: web
-      create_revision: 67323de285b00232883f53b84095eb72be97d35c
-      base_revision: 67323de285b00232883f53b84095eb72be97d35c
-    - platform: windows
       create_revision: 67323de285b00232883f53b84095eb72be97d35c
       base_revision: 67323de285b00232883f53b84095eb72be97d35c
 

--- a/example/.gitignore
+++ b/example/.gitignore
@@ -1,0 +1,45 @@
+# Miscellaneous
+*.class
+*.log
+*.pyc
+*.swp
+.DS_Store
+.atom/
+.build/
+.buildlog/
+.history
+.svn/
+.swiftpm/
+migrate_working_dir/
+
+# IntelliJ related
+*.iml
+*.ipr
+*.iws
+.idea/
+
+# The .vscode folder contains launch configuration and tasks you configure in
+# VS Code which you may wish to be included in version control, so this line
+# is commented out by default.
+#.vscode/
+
+# Flutter/Dart/Pub related
+**/doc/api/
+**/ios/Flutter/.last_build_id
+.dart_tool/
+.flutter-plugins-dependencies
+.pub-cache/
+.pub/
+/build/
+/coverage/
+
+# Symbolication related
+app.*.symbols
+
+# Obfuscation related
+app.*.map.json
+
+# Android Studio will place build artifacts here
+/android/app/debug
+/android/app/profile
+/android/app/release

--- a/example/.metadata
+++ b/example/.metadata
@@ -15,22 +15,7 @@ migration:
     - platform: root
       create_revision: 67323de285b00232883f53b84095eb72be97d35c
       base_revision: 67323de285b00232883f53b84095eb72be97d35c
-    - platform: android
-      create_revision: 67323de285b00232883f53b84095eb72be97d35c
-      base_revision: 67323de285b00232883f53b84095eb72be97d35c
-    - platform: ios
-      create_revision: 67323de285b00232883f53b84095eb72be97d35c
-      base_revision: 67323de285b00232883f53b84095eb72be97d35c
-    - platform: linux
-      create_revision: 67323de285b00232883f53b84095eb72be97d35c
-      base_revision: 67323de285b00232883f53b84095eb72be97d35c
     - platform: macos
-      create_revision: 67323de285b00232883f53b84095eb72be97d35c
-      base_revision: 67323de285b00232883f53b84095eb72be97d35c
-    - platform: web
-      create_revision: 67323de285b00232883f53b84095eb72be97d35c
-      base_revision: 67323de285b00232883f53b84095eb72be97d35c
-    - platform: windows
       create_revision: 67323de285b00232883f53b84095eb72be97d35c
       base_revision: 67323de285b00232883f53b84095eb72be97d35c
 

--- a/example/src/repl.cljd
+++ b/example/src/repl.cljd
@@ -3,40 +3,65 @@
    [flutter-cljd.widgets :as ui]
    [flutter-cljd.shader :as shader]
    [cljd.flutter :as f]
+   ["dart:math" :as math]
+   ["dart:ui" :as dart-ui]
    ["package:flutter/cupertino.dart" :as c]))
 
 ;; ====== PREVIEWS — edit & hot reload ======
 
-(defn gradient-preview []
-  (->> (ui/column 
-        :cross-axis-alignment :stretch 
-        (->> (ui/decorated :gradient {:type :linear
-                                      :colors [:red :blue]
-                                      :begin :left
-                                      :end :right})
-             (ui/expanded))
-        (->> (ui/decorated :gradient {:type :linear
-                                      :colors [:red :blue]
-                                      :begin :left
-                                      :end :right
-                                      :color-space :srgb})
-             (ui/expanded)))
-       (ui/decorated :border-radius 12)
-       (ui/sized {:w 280 :h 200})))
+(defn- rand-color ^dart-ui/Color []
+  (let [rng (math/Random)]
+    (dart-ui/Color.fromARGB 255
+      (.nextInt rng 256)
+      (.nextInt rng 256)
+      (.nextInt rng 256))))
 
-(defn mesh-preview []
-  (ui/decorated
-   {:gradient {:type :mesh
-               :width 3 :height 3
-               :colors [:red :green :blue
-                        :yellow :purple :orange
-                        :cyan :pink :white]}
-    :border-radius 12}
-   (ui/sized {:w 300 :h 300})))
+(defn- rand-palette [n]
+  (vec (repeatedly n rand-color)))
+
+(def -palette (atom (rand-palette 3)))
+
+(defn- gradient-strip [colors cs]
+  (ui/row
+   :cross-axis-alignment :center
+   (ui/sized {:w 56}
+             (ui/text (name cs) :style {:family "monospace" :size 13}))
+   (->> (ui/decorated {:gradient {:type :linear
+                                  :colors colors
+                                  :begin :left
+                                  :end :right
+                                  :color-space cs}
+                       :border-radius 8})
+        (ui/sized {:h 52})
+        ui/expanded)))
+
+(defn gradient-comparison []
+  (f/widget
+   :watch [colors -palette]
+   (ui/padding
+    {:horizontal 24 :vertical 32}
+    (ui/column
+     :main-axis-size :min
+     :cross-axis-alignment :stretch
+     (gradient-strip colors :srgb)
+     (ui/sized {:h 10})
+     (gradient-strip colors :oklab)
+     (ui/sized {:h 10})
+     (gradient-strip colors :oklch)
+     (ui/sized {:h 24})
+     (ui/center
+      (c/CupertinoButton
+       .color (dart-ui/Color 0xFF007AFF)
+       .borderRadius (c/BorderRadius.circular 12.0)
+       .child (c/Text "Random"
+                      .style (c/TextStyle
+                              .color (dart-ui/Color 0xFFFFFFFF)
+                              .fontWeight c/FontWeight.w600))
+       .onPressed #(reset! -palette (rand-palette 3))))))))
 
 ;; ==========================================
 
-(def current gradient-preview)
+(def current gradient-comparison)
 
 (defn ^:async main []
   (await (shader/load-oklab-shader!))

--- a/src/flutter_cljd/types.cljd
+++ b/src/flutter_cljd/types.cljd
@@ -853,7 +853,8 @@
    colors
    stops
    ^double p0x ^double p0y
-   ^double p1x ^double p1y]
+   ^double p1x ^double p1y
+   ^int cs-id]
   (let [n (count colors)]
     (.setFloat shader 0 (.-width rect))
     (.setFloat shader 1 (.-height rect))
@@ -893,6 +894,7 @@
       (do
         (.setFloat shader 5 1.0)
         (.setImageSampler shader 0 (create-gradient-data-texture colors stops))))
+    (.setFloat shader 170 (double cs-id))
     shader))
 
 (declare ->oklab-gradient)
@@ -904,7 +906,8 @@
    begin-align end-align
    center-align
    ^double radius-val
-   ^double start-angle ^double end-angle]
+   ^double start-angle ^double end-angle
+   ^int cs-id]
   :extends (m/Gradient .colors colors .stops stops)
 
   (createShader [this ^ui/Rect rect ^ui/TextDirection? .textDirection]
@@ -917,56 +920,56 @@
         0 (let [b (.withinRect (.resolve ^m/AlignmentGeometry begin-align textDirection) rect)
                 e (.withinRect (.resolve ^m/AlignmentGeometry end-align textDirection) rect)]
             (set-gradient-uniforms! shader rect 0 tm-id colors stops
-                                   (.-dx b) (.-dy b) (.-dx e) (.-dy e)))
+                                   (.-dx b) (.-dy b) (.-dx e) (.-dy e) cs-id))
         ;; Radial
         1 (let [c (.withinRect (.resolve ^m/AlignmentGeometry center-align textDirection) rect)
                 side (.-shortestSide rect)
                 r (* radius-val side)
                 sr (* start-angle side)]
             (set-gradient-uniforms! shader rect 1 tm-id colors stops
-                                   (.-dx c) (.-dy c) r sr))
+                                   (.-dx c) (.-dy c) r sr cs-id))
         ;; Sweep
         2 (let [c (.withinRect (.resolve ^m/AlignmentGeometry center-align textDirection) rect)]
             (set-gradient-uniforms! shader rect 2 tm-id colors stops
-                                   (.-dx c) (.-dy c) start-angle end-angle))
+                                   (.-dx c) (.-dy c) start-angle end-angle cs-id))
         ;; Diamond
         3 (let [c (.withinRect (.resolve ^m/AlignmentGeometry center-align textDirection) rect)
                 side (.-shortestSide rect)
                 r (* radius-val side)
                 sr (* start-angle side)]
             (set-gradient-uniforms! shader rect 3 tm-id colors stops
-                                   (.-dx c) (.-dy c) r sr)))))
+                                   (.-dx c) (.-dy c) r sr cs-id)))))
 
   (scale [this ^double factor]
     (->oklab-gradient
      (mapv #(.withOpacity ^ui/Color % (* (.-opacity ^ui/Color %) factor)) colors)
      stops gradient-type tm-id
-     begin-align end-align center-align radius-val start-angle end-angle))
+     begin-align end-align center-align radius-val start-angle end-angle cs-id))
 
   (withOpacity [this ^double opacity]
     (->oklab-gradient
      (mapv #(.withOpacity ^ui/Color % opacity) colors)
      stops gradient-type tm-id
-     begin-align end-align center-align radius-val start-angle end-angle)))
+     begin-align end-align center-align radius-val start-angle end-angle cs-id)))
 
 (defn- ->oklab-gradient
   [colors stops gradient-type tm-id
-   begin-align end-align center-align radius-val start-angle end-angle]
+   begin-align end-align center-align radius-val start-angle end-angle cs-id]
   (OkLabGradient
    (.from #/(dc/List ui/Color) colors)
    (when stops (.from #/(dc/List dc/double) (map double stops)))
    gradient-type tm-id
-   begin-align end-align center-align radius-val start-angle end-angle))
+   begin-align end-align center-align radius-val start-angle end-angle cs-id))
 
 (defn ^m/Gradient linear-gradient
-  "Creates a LinearGradient. OKLab requires `(shader/load-shaders!)`; falls back to sRGB.
+  "Creates a LinearGradient. OKLab/OKLCH requires `(shader/load-shaders!)`; falls back to sRGB.
 
    - `:begin` (alignment, default: :center-start)
    - `:end` (alignment, default: :center-end)
    - `:colors` (list of colors, default: [:transparent :transparent])
    - `:stops` (list of numbers, default: nil)
    - `:tile-mode` (tile-mode, default: :clamp)
-   - `:color-space` (keyword, default: :oklab): `:oklab` or `:srgb`"
+   - `:color-space` (keyword, default: :oklab): `:oklab`, `:oklch`, or `:srgb`"
   [arg0 & args]
   (let [args (if (empty? args) arg0 (apply hash-map (cons arg0 args)))]
     (cond
@@ -980,9 +983,9 @@
             tm (:tile-mode args :clamp)
             begin (alignment-geometry (:begin args m/AlignmentDirectional.centerStart))
             end (alignment-geometry (:end args m/AlignmentDirectional.centerEnd))]
-        (if (and (= cs :oklab) (shader/oklab-shader-loaded?))
+        (if (and (#{:oklab :oklch} cs) (shader/oklab-shader-loaded?))
           (->oklab-gradient colors stops 0 (tile-mode-id tm)
-                           begin end nil 0.0 0.0 0.0)
+                           begin end nil 0.0 0.0 0.0 (if (= cs :oklch) 1 0))
           (let [[colors stops] (ut/expand-gradient-colors
                                 cs colors stops (:steps args 16))]
             (m/LinearGradient
@@ -994,7 +997,7 @@
       (throw (Exception. (str "Invalid LinearGradient: " args))))))
 
 (defn ^m/Gradient sweep-gradient
-  "Creates a SweepGradient. OKLab requires `(shader/load-shaders!)`; falls back to sRGB.
+  "Creates a SweepGradient. OKLab/OKLCH requires `(shader/load-shaders!)`; falls back to sRGB.
 
    - `:center` (alignment, default: :center)
    - `:start-angle` (number, default: 0)
@@ -1002,7 +1005,7 @@
    - `:colors` (list of colors, default: [:transparent :transparent])
    - `:stops` (list of numbers, default: nil)
    - `:tile-mode` (tile-mode, default: :clamp)
-   - `:color-space` (keyword, default: :oklab): `:oklab` or `:srgb`"
+   - `:color-space` (keyword, default: :oklab): `:oklab`, `:oklch`, or `:srgb`"
   [arg0 & args]
   (let [args (if (empty? args) arg0 (apply hash-map (cons arg0 args)))]
     (cond
@@ -1017,9 +1020,9 @@
             center (alignment-geometry (:center args m/Alignment.center))
             sa (double (:start-angle args 0))
             ea (double (:end-angle args (* 2 π)))]
-        (if (and (= cs :oklab) (shader/oklab-shader-loaded?))
+        (if (and (#{:oklab :oklch} cs) (shader/oklab-shader-loaded?))
           (->oklab-gradient colors stops 2 (tile-mode-id tm)
-                           nil nil center 0.0 sa ea)
+                           nil nil center 0.0 sa ea (if (= cs :oklch) 1 0))
           (let [[colors stops] (ut/expand-gradient-colors
                                 cs colors stops (:steps args 16))]
             (m/SweepGradient
@@ -1032,17 +1035,17 @@
       (throw (Exception. (str "Invalid SweepGradient: " args))))))
 
 (defn ^m/Gradient radial-gradient
-  "Creates a RadialGradient. OKLab requires `(shader/load-shaders!)`; falls back to sRGB.
+  "Creates a RadialGradient. OKLab/OKLCH requires `(shader/load-shaders!)`; falls back to sRGB.
    `:shape :diamond` requires `(shader/load-shaders!)`; falls back to circular radial.
 
    - `:center` (alignment, default: :center)
    - `:radius` (number, default: 0.5) — outer edge, fraction of shortestSide
-   - `:start-radius` (number, default: 0) — inner edge for ring gradients (OKLab only)
+   - `:start-radius` (number, default: 0) — inner edge for ring gradients (OKLab/OKLCH only)
    - `:shape` (keyword, default: :circle): `:circle` or `:diamond` (Manhattan distance)
    - `:colors` (list of colors, default: [:transparent :transparent])
    - `:stops` (list of numbers, default: nil)
    - `:tile-mode` (tile-mode, default: :clamp)
-   - `:color-space` (keyword, default: :oklab): `:oklab` or `:srgb`"
+   - `:color-space` (keyword, default: :oklab): `:oklab`, `:oklch`, or `:srgb`"
   [arg0 & args]
   (let [args (if (empty? args) arg0 (apply hash-map (cons arg0 args)))]
     (cond
@@ -1058,9 +1061,9 @@
             r (double (:radius args 0.5))
             sr (double (:start-radius args 0))
             gtype (if (= (:shape args) :diamond) 3 1)]
-        (if (and (= cs :oklab) (shader/oklab-shader-loaded?))
+        (if (and (#{:oklab :oklch} cs) (shader/oklab-shader-loaded?))
           (->oklab-gradient colors stops gtype (tile-mode-id tm)
-                           nil nil center r sr 0.0)
+                           nil nil center r sr 0.0 (if (= cs :oklch) 1 0))
           (let [[colors stops] (ut/expand-gradient-colors
                                 cs colors stops (:steps args 16))]
             (m/RadialGradient
@@ -1096,7 +1099,8 @@
   [^ui/FragmentShader shader
    ^ui/Rect rect
    ^int grid-w ^int grid-h
-   points colors]
+   points colors
+   ^int cs-id]
   (let [n (* grid-w grid-h)]
     ;; uSize
     (.setFloat shader 0 (.-width rect))
@@ -1141,33 +1145,34 @@
       (do
         (.setFloat shader 6 1.0) ;; uUseTexture
         (.setImageSampler shader 0 (create-mesh-data-texture points colors))))
+    (.setFloat shader 391 (double cs-id))
     shader))
 
 (declare ->oklab-mesh-gradient)
 
 (deftype OkLabMeshGradient
-  [colors ^int grid-w ^int grid-h points]
+  [colors ^int grid-w ^int grid-h points ^int cs-id]
   :extends (m/Gradient .colors colors .stops nil)
 
   (createShader [this ^ui/Rect rect ^ui/TextDirection? .textDirection]
     (let [shader (shader/create-mesh-shader)]
-      (set-mesh-uniforms! shader rect grid-w grid-h points colors)))
+      (set-mesh-uniforms! shader rect grid-w grid-h points colors cs-id)))
 
   (scale [this ^double factor]
     (->oklab-mesh-gradient
      (mapv #(.withOpacity ^ui/Color % (* (.-opacity ^ui/Color %) factor)) colors)
-     grid-w grid-h points))
+     grid-w grid-h points cs-id))
 
   (withOpacity [this ^double opacity]
     (->oklab-mesh-gradient
      (mapv #(.withOpacity ^ui/Color % opacity) colors)
-     grid-w grid-h points)))
+     grid-w grid-h points cs-id)))
 
 (defn- ->oklab-mesh-gradient
-  [colors grid-w grid-h points]
+  [colors grid-w grid-h points cs-id]
   (OkLabMeshGradient
    (.from #/(dc/List ui/Color) colors)
-   grid-w grid-h points))
+   grid-w grid-h points cs-id))
 
 (defn- default-mesh-points [^int w ^int h]
   (let [max-col (dec w)
@@ -1186,6 +1191,7 @@
    - `:colors` (vector of colors, required): one color per grid point, row-major
    - `:points` (vector of [x y], optional): positions in [0,1] space, row-major.
      Defaults to a regular evenly-spaced grid.
+   - `:color-space` (keyword, default: :oklab): `:oklab` or `:oklch`
 
    ```clojure
    (mesh-gradient {:width 3 :height 3
@@ -1203,6 +1209,7 @@
       (let [w (int (:width args))
             h (int (:height args))
             n (* w h)
+            cs (:color-space args :oklab)
             colors (vec (map color (:colors args)))
             points (or (:points args) (default-mesh-points w h))]
         (assert (>= w 2) "mesh-gradient: width must be >= 2")
@@ -1211,7 +1218,7 @@
         (assert (= (count colors) n) "mesh-gradient: colors count must equal width * height")
         (assert (= (count points) n) "mesh-gradient: points count must equal width * height")
         (if (shader/mesh-shader-loaded?)
-          (->oklab-mesh-gradient colors w h points)
+          (->oklab-mesh-gradient colors w h points (if (= cs :oklch) 1 0))
           (m/LinearGradient
            .begin m/Alignment.topLeft .end m/Alignment.bottomRight
            .colors [(first colors) (last colors)]

--- a/src/flutter_cljd/utils.cljd
+++ b/src/flutter_cljd/utils.cljd
@@ -300,6 +300,80 @@
        (oklab-lerp begin end))
      end)))
 
+;;; OKLCH color space (OKLab in polar coordinates)
+
+(defn color->oklch
+  "Converts a `Color` to OKLCH. Returns `[L C H alpha]`.
+   L: lightness [0,1], C: chroma [0,~0.4], H: hue [−π, π].
+
+   ```clojure
+   (color->oklch Colors.red) ; => [0.6279… 0.2576… 0.5016… 1.0]
+   ```"
+  [^ui/Color color]
+  (let [[L a b alpha] (color->oklab color)]
+    [L (math/sqrt (+ (* a a) (* b b))) (math/atan2 b a) alpha]))
+
+(defn oklch->color
+  "Converts OKLCH values to a `Color`.
+
+   ```clojure
+   (oklch->color [0.5 0.1 0.0 1.0])
+   (oklch->color 0.5 0.1 0.0)
+   (oklch->color 0.5 0.1 0.0 1.0)
+   ```"
+  ([[L C H alpha]]
+   (oklch->color L C H alpha))
+  ([L C H]
+   (oklch->color L C H 1.0))
+  ([L C H alpha]
+   (let [C (double C)
+         H (double H)]
+     (oklab->color L (* C (math/cos H)) (* C (math/sin H)) alpha))))
+
+(defn- lerp-hue ^double [^double h1 ^double h2 ^double t]
+  (let [diff (- h2 h1)
+        diff (cond
+               (> diff math/pi) (- diff (* 2 math/pi))
+               (< diff (- math/pi)) (+ diff (* 2 math/pi))
+               :else diff)]
+    (+ h1 (* t diff))))
+
+(defn oklch-lerp
+  "Interpolates between two colors in OKLCH color space.
+   Hue is interpolated along the shortest arc.
+
+   ```clojure
+   (oklch-lerp Colors.red Colors.blue 0.5)
+   ((oklch-lerp Colors.red Colors.blue) 0.5) ; curried form for animations
+   ```"
+  ([from to t]
+   ((oklch-lerp from to) (double t)))
+  ([from to]
+   (let [[l1 c1 h1 alpha1] (color->oklch from)
+         [l2 c2 h2 alpha2] (color->oklch to)]
+     (fn [^double t]
+       (oklch->color
+        (+ l1 (* t (- l2 l1)))
+        (+ c1 (* t (- c2 c1)))
+        (lerp-hue h1 h2 t)
+        (+ alpha1 (* t (- alpha2 alpha1))))))))
+
+(defmethod expand-gradient-colors :oklch [_ colors stops steps]
+  (let [n (count colors)
+        stops (or stops (mapv #(/ (double %) (dec n)) (range n)))
+        result (mapcat
+                (fn [i]
+                  (let [f (oklch-lerp (nth colors i) (nth colors (inc i)))
+                        s1 (nth stops i)
+                        s2 (nth stops (inc i))
+                        end (if (= i (- n 2)) (inc steps) steps)]
+                    (map (fn [j]
+                           (let [t (/ (double j) steps)]
+                             [(f t) (+ s1 (* t (- s2 s1)))]))
+                         (range end))))
+                (range (dec n)))]
+    [(mapv first result) (mapv second result)]))
+
 (defn flatten-children
   "Flattens a nested collection of children and filters out non-Widget elements.
    


### PR DESCRIPTION
## Summary

Added complete OKLCH (perceptually uniform hue) support for gradients and animations, complementing the existing OKLab implementation.

**Key features:**
- CPU color utilities with shortest-arc hue interpolation (`color->oklch`, `oklch->color`, `oklch-lerp`)
- GPU shader support via `uColorSpace` uniform (oklab_gradient.frag, mesh_gradient.frag)
- All gradient types (linear, radial, sweep, diamond, mesh) now accept `:color-space :oklch`
- REPL preview demo with side-by-side gradient comparison (sRGB vs OKLab vs OKLCH)

## Changes

- **src/flutter_cljd/utils.cljd**: OKLCH utilities and gradient expansion
- **src/flutter_cljd/types.cljd**: Gradient API updates with color space support  
- **shaders/oklab_gradient.frag**: OKLCH interpolation with shortest-arc hue
- **shaders/mesh_gradient.frag**: OKLCH support for mesh gradients
- **example/src/repl.cljd**: Interactive preview app for gradient comparison

🧠 Generated with [Claude Code](https://claude.com/claude-code)