### PR TITLE
perf: precompute gradient colors on CPU, skip shader conversion

### DIFF
--- a/example/src/repl.cljd
+++ b/example/src/repl.cljd
@@ -310,19 +310,23 @@
 
 (def -palette (atom (rand-palette 3)))
 
-(defn- gradient-strip [colors cs]
-  (ui/row
-   :cross-axis-alignment :center
-   (ui/sized {:w 56}
-             (ui/text (name cs) :style {:family "monospace" :size 13}))
-   (->> (ui/decorated {:gradient {:type :linear
-                                  :colors colors
-                                  :begin :left
-                                  :end :right
-                                  :color-space cs}
-                       :border-radius 8})
-        (ui/sized {:h 52})
-        ui/expanded)))
+(defn- gradient-strip
+  ([colors cs] (gradient-strip colors cs nil))
+  ([colors cs hue]
+   (ui/row
+    :cross-axis-alignment :center
+    (ui/sized {:w 76}
+              (ui/text (if hue (str (name cs) " " (name hue)) (name cs))
+                       :style {:family "monospace" :size 13}))
+    (->> (ui/decorated {:gradient {:type :linear
+                                   :colors colors
+                                   :begin :left
+                                   :end :right
+                                   :color-space cs
+                                   :hue hue}
+                        :border-radius 8})
+         (ui/sized {:h 52})
+         ui/expanded))))
 
 (defn gradient-comparison []
   (f/widget
@@ -337,6 +341,12 @@
      (gradient-strip colors :oklab)
      (ui/sized {:h 10})
      (gradient-strip colors :oklch)
+     (ui/sized {:h 10})
+     (gradient-strip colors :oklch :longer)
+     (ui/sized {:h 10})
+     (gradient-strip colors :oklch :increasing)
+     (ui/sized {:h 10})
+     (gradient-strip colors :oklch :decreasing)
      (ui/sized {:h 24})
      (ui/center
       (c/CupertinoButton

--- a/src/flutter_cljd/types.cljd
+++ b/src/flutter_cljd/types.cljd
@@ -871,14 +871,18 @@
       (do
         (.setFloat shader 5 0.0)
         ;; Colors (indices 10..137, 32 slots × 4 components)
+        ;; Preconvert to OKLab (L,a,b) or OKLCH (L,C,H) so shader skips conversion per-pixel
         (dotimes [i 32]
           (let [base (+ 10 (* i 4))]
             (if (< i n)
-              (let [^ui/Color c (nth colors i)]
-                (.setFloat shader base (/ (.-red c) 255.0))
-                (.setFloat shader (+ base 1) (/ (.-green c) 255.0))
-                (.setFloat shader (+ base 2) (/ (.-blue c) 255.0))
-                (.setFloat shader (+ base 3) (.-opacity c)))
+              (let [^ui/Color c (nth colors i)
+                    [x y z a] (if (zero? cs-id)
+                                (ut/color->oklab c)
+                                (ut/color->oklch c))]
+                (.setFloat shader base x)
+                (.setFloat shader (+ base 1) y)
+                (.setFloat shader (+ base 2) z)
+                (.setFloat shader (+ base 3) a))
               (do
                 (.setFloat shader base 0.0)
                 (.setFloat shader (+ base 1) 0.0)
@@ -961,6 +965,13 @@
    gradient-type tm-id
    begin-align end-align center-align radius-val start-angle end-angle cs-id))
 
+(defn- oklch-cs-id [hue]
+  (case hue
+    :longer 2
+    :increasing 3
+    :decreasing 4
+    1))
+
 (defn ^m/Gradient linear-gradient
   "Creates a LinearGradient. OKLab/OKLCH requires `(shader/load-shaders!)`; falls back to sRGB.
 
@@ -969,7 +980,9 @@
    - `:colors` (list of colors, default: [:transparent :transparent])
    - `:stops` (list of numbers, default: nil)
    - `:tile-mode` (tile-mode, default: :clamp)
-   - `:color-space` (keyword, default: :oklab): `:oklab`, `:oklch`, or `:srgb`"
+   - `:color-space` (keyword, default: :oklab): `:oklab`, `:oklch`, or `:srgb`
+   - `:hue` (keyword, default: :shorter): `:shorter`, `:longer`, `:increasing`, `:decreasing`
+     Controls hue traversal direction when `:color-space` is `:oklch`."
   [arg0 & args]
   (let [args (if (empty? args) arg0 (apply hash-map (cons arg0 args)))]
     (cond
@@ -978,6 +991,7 @@
 
       (map? args)
       (let [cs (:color-space args :oklab)
+            hue (:hue args)
             colors (vec (gradient-colors (:colors args)))
             stops (:stops args)
             tm (:tile-mode args :clamp)
@@ -985,9 +999,9 @@
             end (alignment-geometry (:end args m/AlignmentDirectional.centerEnd))]
         (if (and (#{:oklab :oklch} cs) (shader/oklab-shader-loaded?))
           (->oklab-gradient colors stops 0 (tile-mode-id tm)
-                           begin end nil 0.0 0.0 0.0 (if (= cs :oklch) 1 0))
+                           begin end nil 0.0 0.0 0.0 (if (= cs :oklch) (oklch-cs-id hue) 0))
           (let [[colors stops] (ut/expand-gradient-colors
-                                cs colors stops (:steps args 16))]
+                                cs colors stops (:steps args 16) hue)]
             (m/LinearGradient
              .begin begin .end end
              .colors colors .stops stops
@@ -1005,7 +1019,9 @@
    - `:colors` (list of colors, default: [:transparent :transparent])
    - `:stops` (list of numbers, default: nil)
    - `:tile-mode` (tile-mode, default: :clamp)
-   - `:color-space` (keyword, default: :oklab): `:oklab`, `:oklch`, or `:srgb`"
+   - `:color-space` (keyword, default: :oklab): `:oklab`, `:oklch`, or `:srgb`
+   - `:hue` (keyword, default: :shorter): `:shorter`, `:longer`, `:increasing`, `:decreasing`
+     Controls hue traversal direction when `:color-space` is `:oklch`."
   [arg0 & args]
   (let [args (if (empty? args) arg0 (apply hash-map (cons arg0 args)))]
     (cond
@@ -1014,6 +1030,7 @@
 
       (map? args)
       (let [cs (:color-space args :oklab)
+            hue (:hue args)
             colors (vec (gradient-colors (:colors args)))
             stops (:stops args)
             tm (:tile-mode args :clamp)
@@ -1022,9 +1039,9 @@
             ea (double (:end-angle args (* 2 π)))]
         (if (and (#{:oklab :oklch} cs) (shader/oklab-shader-loaded?))
           (->oklab-gradient colors stops 2 (tile-mode-id tm)
-                           nil nil center 0.0 sa ea (if (= cs :oklch) 1 0))
+                           nil nil center 0.0 sa ea (if (= cs :oklch) (oklch-cs-id hue) 0))
           (let [[colors stops] (ut/expand-gradient-colors
-                                cs colors stops (:steps args 16))]
+                                cs colors stops (:steps args 16) hue)]
             (m/SweepGradient
              .center center
              .startAngle sa .endAngle ea
@@ -1045,7 +1062,9 @@
    - `:colors` (list of colors, default: [:transparent :transparent])
    - `:stops` (list of numbers, default: nil)
    - `:tile-mode` (tile-mode, default: :clamp)
-   - `:color-space` (keyword, default: :oklab): `:oklab`, `:oklch`, or `:srgb`"
+   - `:color-space` (keyword, default: :oklab): `:oklab`, `:oklch`, or `:srgb`
+   - `:hue` (keyword, default: :shorter): `:shorter`, `:longer`, `:increasing`, `:decreasing`
+     Controls hue traversal direction when `:color-space` is `:oklch`."
   [arg0 & args]
   (let [args (if (empty? args) arg0 (apply hash-map (cons arg0 args)))]
     (cond
@@ -1054,6 +1073,7 @@
 
       (map? args)
       (let [cs (:color-space args :oklab)
+            hue (:hue args)
             colors (vec (gradient-colors (:colors args)))
             stops (:stops args)
             tm (:tile-mode args :clamp)
@@ -1063,9 +1083,9 @@
             gtype (if (= (:shape args) :diamond) 3 1)]
         (if (and (#{:oklab :oklch} cs) (shader/oklab-shader-loaded?))
           (->oklab-gradient colors stops gtype (tile-mode-id tm)
-                           nil nil center r sr 0.0 (if (= cs :oklch) 1 0))
+                           nil nil center r sr 0.0 (if (= cs :oklch) (oklch-cs-id hue) 0))
           (let [[colors stops] (ut/expand-gradient-colors
-                                cs colors stops (:steps args 16))]
+                                cs colors stops (:steps args 16) hue)]
             (m/RadialGradient
              .center center .radius r
              .colors colors .stops stops
@@ -1126,14 +1146,18 @@
                 (.setFloat shader base 0.0)
                 (.setFloat shader (+ base 1) 0.0)))))
         ;; Colors (indices 135..390, 64 slots × 4 components)
+        ;; Preconvert to OKLab (L,a,b) or OKLCH (L,C,H) so gridColorLab skips conversion per-pixel
         (dotimes [i 64]
           (let [base (+ 135 (* i 4))]
             (if (< i n)
-              (let [^ui/Color c (nth colors i)]
-                (.setFloat shader base (/ (.-red c) 255.0))
-                (.setFloat shader (+ base 1) (/ (.-green c) 255.0))
-                (.setFloat shader (+ base 2) (/ (.-blue c) 255.0))
-                (.setFloat shader (+ base 3) (.-opacity c)))
+              (let [^ui/Color c (nth colors i)
+                    [x y z a] (if (zero? cs-id)
+                                (ut/color->oklab c)
+                                (ut/color->oklch c))]
+                (.setFloat shader base x)
+                (.setFloat shader (+ base 1) y)
+                (.setFloat shader (+ base 2) z)
+                (.setFloat shader (+ base 3) a))
               (do
                 (.setFloat shader base 0.0)
                 (.setFloat shader (+ base 1) 0.0)
@@ -1192,6 +1216,8 @@
    - `:points` (vector of [x y], optional): positions in [0,1] space, row-major.
      Defaults to a regular evenly-spaced grid.
    - `:color-space` (keyword, default: :oklab): `:oklab` or `:oklch`
+   - `:hue` (keyword, default: :shorter): `:shorter`, `:longer`, `:increasing`, `:decreasing`
+     Controls hue traversal direction when `:color-space` is `:oklch`.
 
    ```clojure
    (mesh-gradient {:width 3 :height 3
@@ -1210,6 +1236,7 @@
             h (int (:height args))
             n (* w h)
             cs (:color-space args :oklab)
+            hue (:hue args)
             colors (vec (map color (:colors args)))
             points (or (:points args) (default-mesh-points w h))]
         (assert (>= w 2) "mesh-gradient: width must be >= 2")
@@ -1218,7 +1245,7 @@
         (assert (= (count colors) n) "mesh-gradient: colors count must equal width * height")
         (assert (= (count points) n) "mesh-gradient: points count must equal width * height")
         (if (shader/mesh-shader-loaded?)
-          (->oklab-mesh-gradient colors w h points (if (= cs :oklch) 1 0))
+          (->oklab-mesh-gradient colors w h points (if (= cs :oklch) (oklch-cs-id hue) 0))
           (m/LinearGradient
            .begin m/Alignment.topLeft .end m/Alignment.bottomRight
            .colors [(first colors) (last colors)]

--- a/src/flutter_cljd/utils.cljd
+++ b/src/flutter_cljd/utils.cljd
@@ -270,13 +270,15 @@
   "Expands gradient colors in the given color space.
    Returns `[colors stops]`. Override for custom color spaces.
 
-   Dispatches on `color-space` keyword (`:oklab`, `:srgb`, etc.)."
-  (fn [color-space colors stops steps] color-space))
+   Dispatches on `color-space` keyword (`:oklab`, `:srgb`, etc.).
+   The optional `hue-method` arg (`:shorter`, `:longer`, `:increasing`, `:decreasing`)
+   controls hue traversal direction for OKLCH."
+  (fn [color-space colors stops steps hue-method] color-space))
 
-(defmethod expand-gradient-colors :srgb [_ colors stops _steps]
+(defmethod expand-gradient-colors :srgb [_ colors stops _steps _hue]
   [colors stops])
 
-(defmethod expand-gradient-colors :oklab [_ colors stops steps]
+(defmethod expand-gradient-colors :oklab [_ colors stops steps _hue]
   (let [n (count colors)
         stops (or stops (mapv #(/ (double %) (dec n)) (range n)))
         result (mapcat
@@ -330,40 +332,67 @@
          H (double H)]
      (oklab->color L (* C (math/cos H)) (* C (math/sin H)) alpha))))
 
-(defn- lerp-hue ^double [^double h1 ^double h2 ^double t]
+(defn- hue-id ^long [hue-method]
+  (case hue-method
+    :longer 2
+    :increasing 3
+    :decreasing 4
+    1))
+
+(defn- lerp-hue ^double [^double h1 ^double h2 ^double t ^long hid]
   (let [diff (- h2 h1)
-        diff (cond
-               (> diff math/pi) (- diff (* 2 math/pi))
-               (< diff (- math/pi)) (+ diff (* 2 math/pi))
-               :else diff)]
+        two-pi (* 2 math/pi)
+        diff (case hid
+               2 (cond
+                   (and (pos? diff) (< diff math/pi)) (- diff two-pi)
+                   (and (neg? diff) (> diff (- math/pi))) (+ diff two-pi)
+                   :else diff)
+               3 (if (neg? diff) (+ diff two-pi) diff)
+               4 (if (pos? diff) (- diff two-pi) diff)
+               (cond
+                 (> diff math/pi) (- diff two-pi)
+                 (< diff (- math/pi)) (+ diff two-pi)
+                 :else diff))]
     (+ h1 (* t diff))))
 
 (defn oklch-lerp
   "Interpolates between two colors in OKLCH color space.
-   Hue is interpolated along the shortest arc.
+
+   The optional `hue-method` controls how the hue angle is traversed:
+   - `:shorter` (default) — shortest arc
+   - `:longer` — longest arc
+   - `:increasing` — always increase hue angle
+   - `:decreasing` — always decrease hue angle
 
    ```clojure
    (oklch-lerp Colors.red Colors.blue 0.5)
-   ((oklch-lerp Colors.red Colors.blue) 0.5) ; curried form for animations
+   ((oklch-lerp Colors.red Colors.blue) 0.5)          ; curried, shortest arc
+   ((oklch-lerp Colors.red Colors.blue :longer) 0.5)  ; curried, longer arc
+   (oklch-lerp Colors.red Colors.blue :longer 0.5)    ; direct form
    ```"
-  ([from to t]
-   ((oklch-lerp from to) (double t)))
   ([from to]
-   (let [[l1 c1 h1 alpha1] (color->oklch from)
-         [l2 c2 h2 alpha2] (color->oklch to)]
-     (fn [^double t]
-       (oklch->color
-        (+ l1 (* t (- l2 l1)))
-        (+ c1 (* t (- c2 c1)))
-        (lerp-hue h1 h2 t)
-        (+ alpha1 (* t (- alpha2 alpha1))))))))
+   (oklch-lerp from to :shorter))
+  ([from to x]
+   (if (keyword? x)
+     (let [hid (hue-id x)
+           [l1 c1 h1 alpha1] (color->oklch from)
+           [l2 c2 h2 alpha2] (color->oklch to)]
+       (fn [^double t]
+         (oklch->color
+          (+ l1 (* t (- l2 l1)))
+          (+ c1 (* t (- c2 c1)))
+          (lerp-hue h1 h2 t hid)
+          (+ alpha1 (* t (- alpha2 alpha1))))))
+     ((oklch-lerp from to) (double x))))
+  ([from to hue-method t]
+   ((oklch-lerp from to hue-method) (double t))))
 
-(defmethod expand-gradient-colors :oklch [_ colors stops steps]
+(defmethod expand-gradient-colors :oklch [_ colors stops steps hue-method]
   (let [n (count colors)
         stops (or stops (mapv #(/ (double %) (dec n)) (range n)))
         result (mapcat
                 (fn [i]
-                  (let [f (oklch-lerp (nth colors i) (nth colors (inc i)))
+                  (let [f (oklch-lerp (nth colors i) (nth colors (inc i)) (or hue-method :shorter))
                         s1 (nth stops i)
                         s2 (nth stops (inc i))
                         end (if (= i (- n 2)) (inc steps) steps)]


### PR DESCRIPTION
## Summary
Optimize shader gradients by moving color space conversions from per-pixel GPU work to CPU setup phase. Precompute OKLab/OKLCH colors before uploading to shader uniforms, eliminating repeated conversions for every pixel.

Uniform path (≤32 stops): Saves 2×(3 cbrt + 6 sRGB polynomials) per pixel in OKLab mode; additionally 2×(atan2 + sqrt) in OKLCH mode.
Mesh gradient: 16×gridColorLab calls per pixel now skip conversions entirely in uniform path.
Texture path (>32 stops): Unchanged, preserves float precision.

Add comprehensive OKLCH hue mode support in CPU fallback paths with `:shorter/:longer/:increasing/:decreasing` modes throughout the stack.

## Test plan
- Run gradient examples with OKLab and all four OKLCH hue modes (shorter/longer/increasing/decreasing)
- Verify visual output matches previous behavior
- Compare GPU frame time in DevTools for gradient-heavy views
- Test both uniform path (≤32 colors) and texture path (>32 colors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)